### PR TITLE
refactor: remove Index type from AST

### DIFF
--- a/Export.lean
+++ b/Export.lean
@@ -82,7 +82,6 @@ run_meta
   flip List.forM (genPython h)
     [ `NKL.Const
     , `NKL.Expr
-    , `NKL.Index
     , `NKL.Stmt
     , `NKL.Fun
     ]

--- a/NKL/NKI.lean
+++ b/NKL/NKI.lean
@@ -20,28 +20,22 @@ inductive Const where
   | int (value: Int)
   | float (value: Float)
   | string (value: String)
+  | dots
   deriving Repr, BEq, Lean.ToJson, Lean.FromJson
 
-mutual
 inductive Expr where
   | value (c: Const)
   | bvar (name: String)
   | var (name value: String)
-  | subscript (tensor: Expr) (ix: List Index)
+  | subscript (tensor: Expr) (ix: List Expr)
+  | slice (l u step: Expr)
   | binop (op: String) (left right: Expr)
   | cond (e thn els: Expr)
   | tuple (xs: List Expr)
   | list (xs: List Expr)
   | call (f: Expr) (args: List Expr)
-  | gridcall (f: Expr) (ix: List Index) (args: List Expr)
+  | gridcall (f: Expr) (ix: List Expr) (args: List Expr)
   deriving Repr, BEq, Lean.ToJson, Lean.FromJson
-
-inductive Index where
-  | coord (i : Expr)
-  | slice (l u step: Expr)
-  | dots
-  deriving Repr, BEq, Lean.ToJson, Lean.FromJson
-end
 
 inductive Stmt where
   | ret (e: Expr)

--- a/NKL/PrettyPrint.lean
+++ b/NKL/PrettyPrint.lean
@@ -15,35 +15,27 @@ instance : ToString Const where
   | .int i => toString i
   | .float f => toString f
   | .string s => s
-
+  | .dots => "..."
 
 mutual
 private partial def exps_ s l := String.intercalate s (List.map expr l)
 private partial def exps := exps_ ","
-private partial def ndxs l := String.intercalate "," (List.map ndx l)
 
 private partial def expr : Expr -> String
   | .value c => toString c
   | .bvar s | .var s _ => s
-  | .subscript e ix => expr e ++ "[" ++ ndxs ix ++ "]"
+  | .subscript e ix => expr e ++ "[" ++ exps ix ++ "]"
+  | .slice l u s => exps_ ":" [l,u,s]
   | .binop op l r => op ++ "(" ++ expr l ++ "," ++ expr r ++ ")"
   | .cond e thn els => expr thn ++ " if " ++ expr e ++ " else " ++ expr els
   | .tuple es => "(" ++ exps es ++ ")"
   | .list es => "[" ++  exps es ++ "]"
   | .call f es => expr f ++ "(" ++ exps es ++ ")"
-  | .gridcall f ix es => expr f ++ "[" ++ ndxs ix ++ "](" ++ exps es ++ ")"
-
-private partial def ndx : Index -> String
-  | .coord e => expr e
-  | .slice l u s => exps_ ":" [l,u,s]
-  | .dots => "..."
+  | .gridcall f ix es => expr f ++ "[" ++ exps ix ++ "](" ++ exps es ++ ")"
 end
 
 instance : ToString Expr where
   toString := expr
-
-instance : ToString Index where
-  toString := ndx
 
 mutual
 private partial def stmts sp l :=

--- a/interop/test/test_json.py
+++ b/interop/test/test_json.py
@@ -40,11 +40,11 @@ nil = Value(Nil())
 
 @pytest.mark.parametrize("term",
     [ [],
-      [Coord(var)],
-      [Coord(var), Coord(nil)],
+      [var],
+      [var, nil],
       [Slice(var, var, var)],
-      [Slice(nil, nil, nil), Coord(nil)],
-      [Dots()],
+      [Slice(nil, nil, nil), nil],
+      [Value(Dots())],
     ])
 def test_subscript(term):
   load(Fun("f", [], [Assign(Var("a", 0), Subscript(var, term))]))


### PR DESCRIPTION
This change brings the NKI AST closer to the original Python AST, at the expense of losing some syntactic constraints. This will make it easier to do more of the processing on the Lean side.