### PR TITLE
feat: add global references and arguments

### DIFF
--- a/NKL/FFI.lean
+++ b/NKL/FFI.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau
 -/
 import Lean
-import NKL.NKI
-import NKL.PrettyPrint
 import NKL.Python
 
 namespace NKL
@@ -15,15 +13,15 @@ local instance : MonadLift (Except String) IO where
     | .ok x => return x
     | .error s => throw $ .userError s
 
-@[export parse_json_old]
-def parse_json_old (json : String) : IO Unit := do
-  let jsn <- Lean.Json.parse json
-  let f:Fun <- Lean.fromJson? jsn
-  print_nki f
-
 @[export parse_json]
 def parse_json (s : String) : IO Unit := do
   let kernel <- Python.Parsing.parse s
   let names := kernel.funcs.map fun x => x.fst
   let names := String.intercalate "," names
   IO.println s!"Found functions: {names}"
+  for x in kernel.args do
+    IO.println s!"arg: {repr x}"
+  for x in kernel.kwargs do
+    IO.println s!"arg: {repr x}"
+  for x in kernel.globals do
+    IO.println s!"global: {repr x}"


### PR DESCRIPTION
Add ability to capture global references, including function arguments when parsing kernels. Globals and arguments are directly encoded as KLR terms.