### PR TITLE
refactor: make some partial functions total

### DIFF
--- a/NKL/FFI.lean
+++ b/NKL/FFI.lean
@@ -11,7 +11,7 @@ import NKL.Trace
 namespace NKL
 open NKL.KLR
 
-local instance : MonadLift (Except String) IO where
+local instance : MonadLift Err IO where
   monadLift
     | .ok x => return x
     | .error s => throw $ .userError s
@@ -21,4 +21,4 @@ def parse_json (s : String) : IO Unit := do
   let kernel <- Python.Parsing.parse s
   let stmts <- NKL.Trace.runNKIKernel kernel
   for s in stmts do
-    IO.println ("  " ++ Lean.format s) --s!"{s}\n{repr s}"
+    IO.println ("  " ++ Lean.format s)

--- a/NKL/KLR/Basic.lean
+++ b/NKL/KLR/Basic.lean
@@ -45,38 +45,6 @@ inductive Const where
   | string (value : String)
   deriving Repr, BEq
 
-namespace Const
-
--- Python-like rules for conversion to boolean
-def isTrue : Const -> Bool
-  | .none     => false
-  | .bool b   => b
-  | .int i    => i != 0
-  | .float f  => f != 0.0
-  | .string s => s != ""
-
--- Python-like rules for conversion to integer
-def toInt : Const -> Except String Int
-  | .none       => throw "none cannot be converted to an integer"
-  | .bool true  => return 1
-  | .bool false => return 0
-  | .int i      => return i
-  | .float f    =>
-      -- Python is a bit strange here, it truncates both
-      -- positive and negative numbers toward zero
-      if f < 0.0 then
-        return (Int.ofNat (Float.floor (-f)).toUInt64.toNat).neg
-      else
-        return Int.ofNat (Float.floor f).toUInt64.toNat
-  | .string s   =>
-      -- Fortunately, Lean's String.toInt appears to be compatible
-      -- with Python's int(string) conversion.
-      match s.toInt? with
-      | .none  => throw s!"string {s} cannot be converted to an integer"
-      | .some i => return i
-
-end Const
-
 -- This corresponds to the "Quasi-Affine Expressions" in Neuron.
 -- Note, `floor` is the usual integer division.
 inductive IndexExpr where

--- a/NKL/KLR/Encode.lean
+++ b/NKL/KLR/Encode.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau
 -/
+import NKL.Util
 import NKL.KLR.Basic
 
 /-!
@@ -12,15 +13,15 @@ import NKL.KLR.Basic
 
 namespace NKL.KLR
 
--- All of the encode function are pure; decoding uses an instance of EStateM.
+-- All of the encode function are pure; decoding uses an instance of StM.
 
-abbrev DecodeM := EStateM String ByteArray.Iterator
+abbrev DecodeM := StM ByteArray.Iterator
 
 def decode' (f : DecodeM a) (ba : ByteArray) : Option a :=
-  EStateM.run' f ba.iter
+  f.run' ba.iter
 
-def decode (f : DecodeM a) (ba : ByteArray) : Except String a :=
-  match EStateM.run f ba.iter with
+def decode (f : DecodeM a) (ba : ByteArray) : Err a :=
+  match f.run ba.iter with
   | .ok x _ => .ok x
   | .error s _ => .error s
 

--- a/NKL/Python.lean
+++ b/NKL/Python.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Paul Govereau
 -/
 import Lean
+import NKL.Util
 
 /-!
 # Abstract syntax of Python functions
@@ -172,12 +173,7 @@ open Lean
 -- span (Pos) is saved while traversing the tree to identify the location
 -- of any errors in the original program
 
-abbrev Parser := EStateM String Pos
-
-local instance : MonadLift (Except String) Parser where
-  monadLift
-    | .ok x => return x
-    | .error s => throw s
+abbrev Parser := StM Pos
 
 private def str : Json -> Parser String :=
   monadLift ∘ Json.getStr?
@@ -364,7 +360,7 @@ def kernel (j : Json) : Parser Kernel := do
   let globals <- field (dict global) j "globals"
   return Kernel.mk name funcs args kwargs globals
 
-def parse (s : String) : Except String Kernel := do
+def parse (s : String) : Err Kernel := do
   let jsn <- Json.parse s
   match kernel jsn {} with
   | .ok x _ => .ok x

--- a/NKL/Trace.lean
+++ b/NKL/Trace.lean
@@ -13,7 +13,7 @@ import NKL.Trace.NKI
 
 namespace NKL.Trace
 
-def runNKIKernel (k : NKL.Python.Kernel) : Except String (List NKL.KLR.Stmt) :=
+def runNKIKernel (k : NKL.Python.Kernel) : Err (List NKL.KLR.Stmt) :=
   tracer ⟨ .ofList NKIEnv, #[] ⟩ do
     traceKernel k
     let g <- get

--- a/NKL/Trace/Builtin.lean
+++ b/NKL/Trace/Builtin.lean
@@ -14,10 +14,10 @@ import NKL.Trace.Types
 namespace NKL.Trace
 open NKL.KLR
 
-abbrev BuiltinAttr := String -> ErrorM Term
+abbrev BuiltinAttr := String -> Err Term
 abbrev GlobalAttr  := String -> TraceM Term
 
-abbrev BuiltinFn := List Expr -> List (String × Expr) -> ErrorM Term
+abbrev BuiltinFn := List Expr -> List (String × Expr) -> Err Term
 abbrev GlobalFn  := List Term -> List (String × Term) -> TraceM Term
 
 def noattrs [Monad m] [MonadExcept String m] : Name -> String -> m a :=
@@ -61,7 +61,7 @@ def simple_object {a : Type}
   , call := uncallable name
   }
 where
-  attr_fn (attr : String) : Except String Term :=
+  attr_fn (attr : String) : Err Term :=
     match attrs.find? (fun x => x.fst == attr) with
     | none => .error s!"{attr} is not an attribute of {name}"
     | some (_,fn) => .ok (.object $ simple_function (name.str attr) (fn x))

--- a/NKL/Util.lean
+++ b/NKL/Util.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Govereau
+-/
+
+-- Common Utilities
+
+namespace NKL
+
+/-
+The default choice for an error monad is `Except String`, used for simple
+computations that can fail.
+
+This is defined as a notation so that it can be used within mutually recursive
+inductive types without issues. (abbrev introduces a new definition which
+cannot be used in a mutually recursive inductive)
+-/
+notation "Err" => Except String
+
+/-
+The default choice for a state monad is `EStateM String`.
+Again, we use a notation for the same reason as for `Err`.
+
+Provide automatic lifting of Err, for any state monad instance.
+-/
+notation "StM" => EStateM String
+
+instance : MonadLift Err (StM a) where
+  monadLift
+    | .ok x => .ok x
+    | .error s => .error s
+
+/-
+A common issue is failure to prove termination automatically when using
+List.mapM. There is a work-around for this which involves introducing
+`{ x // x ∈ l }` in place of the list `l`.
+
+We can capture this trick in a notation. Note we need to use a notation and not
+a definition because the proof object `x∈l` needs to be available to the
+termination proof tactics, in the scope of the original function.
+
+Writing, `List.mapM f l`, as `f ▷ l` doesn't break the termination proof.
+Note: ▷ is typed as \rhd
+-/
+notation f "▷" l =>
+  List.mapM (fun ⟨ x, _ ⟩ => f x) (List.attach l)


### PR DESCRIPTION
This patch cleans up a few cases of partial definitions, making them total. There is also a small amount of refactoring and renaming to be consistent with TensorLib.